### PR TITLE
Clear game canvas before drawing player

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
   }
 
   function draw(){
+    ctx.clearRect(0, 0, innerWidth, innerHeight);
     drawBackground();
     const px=player.x, py=player.y;
     if(spriteReady){ const {sx,sy,sw,sh}=frameRect(player.dir,player.frame); ctx.imageSmoothingEnabled=false; ctx.drawImage(sprite, sx,sy,sw,sh, Math.round(px-sw/2), Math.round(py-sh/2), sw, sh); }


### PR DESCRIPTION
## Summary
- clear the game canvas at the start of each draw call so previously rendered frames are removed before redrawing the player sprite or fallback

## Testing
- Manual verification via browser: moved the character to confirm no trails remain

------
https://chatgpt.com/codex/tasks/task_b_68cc6db81d448327bdbe53c4feeb8ff0