### PR TITLE
Add cel shading and outline pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,20 +43,165 @@
   const gameC = document.getElementById('game');
   const bg = bgC.getContext('2d');
   const ctx = gameC.getContext('2d');
+
+  // Global graphics configuration used by the toon pipeline.
+  const Graphics={
+    pixelArtMode:false,
+    renderScale:1,
+    ambientDarkness:0.35,
+    outlineColor:'#111',
+    outlineThickness:1,
+    toneLevels:[0.0,0.5,1.0],
+    lights:[],
+    playerLightEnabled:true,
+    playerLightRadius:220,
+    playerLightIntensity:0.85,
+    sceneCanvas:document.createElement('canvas'),
+    lightingCanvas:document.createElement('canvas'),
+    _outlineBuffer:document.createElement('canvas')
+  };
+  Graphics.sceneCtx=Graphics.sceneCanvas.getContext('2d');
+  Graphics.lightingCtx=Graphics.lightingCanvas.getContext('2d');
+  Graphics._outlineCtx=Graphics._outlineBuffer.getContext('2d');
+
+  function applyPixelArtSettings(){
+    const smoothing=!Graphics.pixelArtMode;
+    [ctx,bg,Graphics.sceneCtx,Graphics.lightingCtx,Graphics._outlineCtx].forEach(g=>{
+      if(g) g.imageSmoothingEnabled=smoothing;
+    });
+  }
+
+  function setLights(list){
+    Graphics.lights=Array.isArray(list)?list.map(l=>({
+      x:Number(l.x)||0,
+      y:Number(l.y)||0,
+      radius:Math.max(1,Number(l.radius)||0),
+      intensity:Math.max(0,Math.min(1,Number(l.intensity ?? 1)))
+    })) : [];
+  }
+  function setPixelArtMode(flag){
+    Graphics.pixelArtMode=!!flag;
+    applyPixelArtSettings();
+  }
+  function setAmbientDarkness(v){
+    Graphics.ambientDarkness=Math.max(0,Math.min(1,Number(v)||0));
+  }
+
+  window.Graphics=Graphics;
+  window.setLights=setLights;
+  window.setPixelArtMode=setPixelArtMode;
+  window.setAmbientDarkness=setAmbientDarkness;
+
+  applyPixelArtSettings();
+
+  // ===== Outline helpers =====
+  const OUTLINE_OFFSETS_BASE=[[-1,0],[1,0],[0,-1],[0,1],[-1,-1],[1,-1],[-1,1],[1,1]];
+  function snapPixel(v){ return Graphics.pixelArtMode?Math.round(v):v; }
+
+  function ensureOutlineBufferSize(width,height){
+    const canvas=Graphics._outlineBuffer;
+    const targetW=Math.max(width,1);
+    const targetH=Math.max(height,1);
+    if(canvas.width<targetW) canvas.width=targetW;
+    if(canvas.height<targetH) canvas.height=targetH;
+    Graphics._outlineCtx.setTransform(1,0,0,1,0,0);
+  }
+
+  function drawOutlinedSprite(targetCtx,image,sx,sy,sw,sh,dx,dy,dw=sw,dh=sh,outlineColor=Graphics.outlineColor,thickness=Graphics.outlineThickness){
+    if(!image) return;
+    const color=outlineColor ?? Graphics.outlineColor;
+    const t=Math.max(0.5,Number(thickness)||0);
+    const offset=Graphics.pixelArtMode?Math.max(1,Math.round(t)):t;
+    const pad=offset+2;
+    const offW=Math.ceil(dw+pad*2);
+    const offH=Math.ceil(dh+pad*2);
+    ensureOutlineBufferSize(offW,offH);
+    const octx=Graphics._outlineCtx;
+    octx.save();
+    octx.clearRect(0,0,offW,offH);
+    octx.imageSmoothingEnabled=!Graphics.pixelArtMode;
+    octx.drawImage(image,sx,sy,sw,sh,pad,pad,dw,dh);
+    octx.globalCompositeOperation='source-in';
+    octx.fillStyle=color;
+    octx.fillRect(0,0,offW,offH);
+    octx.globalCompositeOperation='source-over';
+    octx.restore();
+
+    const baseX=snapPixel(dx-pad);
+    const baseY=snapPixel(dy-pad);
+    for(const [ox,oy] of OUTLINE_OFFSETS_BASE){
+      const px=Graphics.pixelArtMode?snapPixel(baseX+ox*offset):baseX+ox*offset;
+      const py=Graphics.pixelArtMode?snapPixel(baseY+oy*offset):baseY+oy*offset;
+      targetCtx.drawImage(Graphics._outlineBuffer,0,0,offW,offH,px,py,offW,offH);
+    }
+    targetCtx.drawImage(image,sx,sy,sw,sh,snapPixel(dx),snapPixel(dy),dw,dh);
+  }
+
+  function drawOutlinedRect(targetCtx,x,y,w,h,color,outlineColor=Graphics.outlineColor,thickness=Graphics.outlineThickness){
+    const t=Math.max(0.5,Number(thickness)||0);
+    const offset=Graphics.pixelArtMode?Math.max(1,Math.round(t)):t;
+    const pad=offset+2;
+    const offW=Math.ceil(w+pad*2);
+    const offH=Math.ceil(h+pad*2);
+    ensureOutlineBufferSize(offW,offH);
+    const octx=Graphics._outlineCtx;
+    const outline=outlineColor ?? Graphics.outlineColor;
+    octx.save();
+    octx.clearRect(0,0,offW,offH);
+    octx.fillStyle='#fff';
+    octx.fillRect(pad,pad,w,h);
+    octx.globalCompositeOperation='source-in';
+    octx.fillStyle=outline;
+    octx.fillRect(0,0,offW,offH);
+    octx.globalCompositeOperation='source-over';
+    octx.restore();
+
+    const baseX=snapPixel(x-pad);
+    const baseY=snapPixel(y-pad);
+    for(const [ox,oy] of OUTLINE_OFFSETS_BASE){
+      const px=Graphics.pixelArtMode?snapPixel(baseX+ox*offset):baseX+ox*offset;
+      const py=Graphics.pixelArtMode?snapPixel(baseY+oy*offset):baseY+oy*offset;
+      targetCtx.drawImage(Graphics._outlineBuffer,0,0,offW,offH,px,py,offW,offH);
+    }
+    targetCtx.fillStyle=color;
+    targetCtx.fillRect(snapPixel(x),snapPixel(y),w,h);
+  }
+
   let currentRoom=null;          // currently active room definition
   const currentObstacles=[];     // obstacles for collision/rendering
   const currentProps=[];         // decorative props for the current room
   let currentParallaxLayers=[];  // parallax layers per room (defaults later)
   let camera=null;
-  ctx.imageSmoothingEnabled=false;
-  bg.imageSmoothingEnabled=false;
   function resize(){
-    bgC.width=innerWidth*dpr;
-    bgC.height=innerHeight*dpr;
+    const scale=Math.max(0.25, Number(Graphics.renderScale)||1);
+    const screenW=innerWidth*dpr;
+    const screenH=innerHeight*dpr;
+
+    bgC.width=screenW;
+    bgC.height=screenH;
     bg.setTransform(dpr,0,0,dpr,0,0);
-    gameC.width=innerWidth*dpr;
-    gameC.height=innerHeight*dpr;
+
+    gameC.width=screenW;
+    gameC.height=screenH;
     ctx.setTransform(dpr,0,0,dpr,0,0);
+
+    const offW=Math.max(1,Math.round(screenW*scale));
+    const offH=Math.max(1,Math.round(screenH*scale));
+    if(Graphics.sceneCanvas.width!==offW || Graphics.sceneCanvas.height!==offH){
+      Graphics.sceneCanvas.width=offW;
+      Graphics.sceneCanvas.height=offH;
+    }
+    if(Graphics.lightingCanvas.width!==offW || Graphics.lightingCanvas.height!==offH){
+      Graphics.lightingCanvas.width=offW;
+      Graphics.lightingCanvas.height=offH;
+    }
+    Graphics.sceneCtx.setTransform(dpr*scale,0,0,dpr*scale,0,0);
+    Graphics.lightingCtx.setTransform(dpr*scale,0,0,dpr*scale,0,0);
+
+    applyPixelArtSettings();
+
+    drawBackground();
+
     if(camera){
       resizeCamera();
       clampCameraToWorld();
@@ -225,8 +370,13 @@
     frame:1,
     dir:'down',
     tick:0,
-    collider:{ w:24, h:28 }
+    collider:{ w:24, h:28 },
+    state:'idle',
+    wasMoving:false,
+    outlineColor:'#070b16',
+    outlineThickness:1.5
   };
+  const particles=[];
   const pressed=new Set();
   function normKey(k){ const map={Left:'ArrowLeft',Right:'ArrowRight',Up:'ArrowUp',Down:'ArrowDown'}; return map[k] || (k.length===1?k.toLowerCase():k); }
   // Global keybinds: WASD/arrow for movement, 'N' jumps to the next room.
@@ -316,7 +466,11 @@
       h:Number(p.h)||32,
       color:p.color||'#94a3b8',
       spriteURL:p.spriteURL||null,
-      sprite:null
+      sprite:null,
+      shadow:typeof p.shadow==='boolean'?p.shadow:undefined,
+      height:Number(p.height)||0,
+      outlineColor:p.outlineColor||null,
+      outlineThickness:typeof p.outlineThickness==='number'?p.outlineThickness:null
     }));
   }
 
@@ -330,8 +484,12 @@
         { x:520, y:620, w:260, h:56, type:'rock' }
       ],
       props:[
-        { x:520, y:260, w:48, h:48, spriteURL:'assets/Male 18-1.png' },
-        { x:860, y:480, w:40, h:40 }
+        { x:520, y:260, w:48, h:48, spriteURL:'assets/Male 18-1.png', shadow:true, height:24 },
+        { x:860, y:480, w:40, h:40, color:'#64748b', shadow:true }
+      ],
+      lights:[
+        { x:420, y:340, radius:280, intensity:1 },
+        { x:760, y:500, radius:240, intensity:0.8 }
       ]
     },
     room2:{
@@ -342,8 +500,12 @@
         { x:540, y:740, w:360, h:70, type:'rock' }
       ],
       props:[
-        { x:600, y:520, w:60, h:60 },
-        { x:1040, y:360, w:96, h:96, spriteURL:'assets/Male 18-1.png' }
+        { x:600, y:520, w:60, h:60, color:'#475569', shadow:true },
+        { x:1040, y:360, w:96, h:96, spriteURL:'assets/Male 18-1.png', shadow:true, height:36 }
+      ],
+      lights:[
+        { x:720, y:400, radius:260, intensity:0.9 },
+        { x:1080, y:360, radius:220, intensity:0.7 }
       ]
     }
   };
@@ -378,6 +540,8 @@
       ? roomData.parallaxLayers.map(layer=>({ ...layer }))
       : createDefaultParallaxLayers();
 
+    setLights(roomData.lights||[]);
+
     currentRoom={
       name:roomData.name || '',
       spawn,
@@ -387,7 +551,8 @@
         width:roomData.world?.width ?? DEFAULT_WORLD.width,
         height:roomData.world?.height ?? DEFAULT_WORLD.height
       },
-      parallaxLayers:currentParallaxLayers
+      parallaxLayers:currentParallaxLayers,
+      lights:Graphics.lights
     };
 
     // Move the player to the new spawn and recentre the camera.
@@ -513,13 +678,21 @@
 
     const moveX=dx*player.speed*dt;
     const moveY=dy*player.speed*dt;
+    const isMoving=Math.abs(moveX)>0.001 || Math.abs(moveY)>0.001;
+    player.state=isMoving?'run':'idle';
+    if(isMoving && !player.wasMoving){
+      spawnDustBurst(4,dx,dy);
+    } else if(!isMoving && player.wasMoving){
+      spawnDustBurst(3,0,0);
+    }
+    player.wasMoving=isMoving;
 
     tryMove('x',moveX,obstacles);
     clampPlayerToWorld();
     tryMove('y',moveY,obstacles);
     clampPlayerToWorld();
 
-    if(len>0){
+    if(isMoving){
       player.tick+=dt;
       if(player.tick>0.18){ player.frame=(player.frame+1)%SHEET_COLS; player.tick=0; }
     } else {
@@ -528,32 +701,31 @@
     }
 
     updateCamera();
+    updateParticles(dt);
   }
 
   function drawParallaxLayers(){
+    const g=Graphics.sceneCtx;
     const layers=getParallaxLayers();
-    // Always start with a clear so the frame is fresh.
-    ctx.clearRect(0,0,camera.width,camera.height);
 
-    // Base fill to avoid gaps when the world is smaller than the view.
-    const sky=ctx.createLinearGradient(0,0,0,camera.height);
+    g.clearRect(0,0,camera.width,camera.height);
+
+    const sky=g.createLinearGradient(0,0,0,camera.height);
     sky.addColorStop(0,'#0b1326');
     sky.addColorStop(1,'#0b1020');
-    ctx.fillStyle=sky;
-    ctx.fillRect(0,0,camera.width,camera.height);
+    g.fillStyle=sky;
+    g.fillRect(0,0,camera.width,camera.height);
 
     for(const layer of layers){
       const factor=layer.factor ?? 0.5;
-      // Parallax uses the camera offset scaled by a factor. Distant layers move
-      // less (small factor), while near layers move more (large factor).
       const offsetX=(camera.x*factor)% (layer.spacing||camera.width);
       const offsetY=(camera.y*factor)% (layer.spacing||camera.height);
       if(layer.type==='gradient'){
-        const grad=ctx.createLinearGradient(0,0,0,camera.height);
+        const grad=g.createLinearGradient(0,0,0,camera.height);
         grad.addColorStop(0,layer.colors?.[0]||'#0b1326');
         grad.addColorStop(1,layer.colors?.[1]||'#111827');
-        ctx.fillStyle=grad;
-        ctx.fillRect(0,0,camera.width,camera.height);
+        g.fillStyle=grad;
+        g.fillRect(0,0,camera.width,camera.height);
         continue;
       }
       if(layer.type==='hills'){
@@ -562,22 +734,22 @@
         const base=layer.base||300;
         const startX=-spacing*2 - offsetX;
         const endX=camera.width+spacing*2;
-        ctx.fillStyle=layer.color||'#1e293b';
+        g.fillStyle=layer.color||'#1e293b';
         for(let x=startX; x<endX; x+=spacing){
           const peakX=x+spacing/2;
-          ctx.beginPath();
-          ctx.moveTo(x, camera.height - base + offsetY);
-          ctx.quadraticCurveTo(peakX, camera.height - (base+amplitude) + offsetY, x+spacing, camera.height - base + offsetY);
-          ctx.lineTo(x+spacing, camera.height+20);
-          ctx.lineTo(x, camera.height+20);
-          ctx.closePath();
-          ctx.fill();
+          g.beginPath();
+          g.moveTo(x, camera.height - base + offsetY);
+          g.quadraticCurveTo(peakX, camera.height - (base+amplitude) + offsetY, x+spacing, camera.height - base + offsetY);
+          g.lineTo(x+spacing, camera.height+20);
+          g.lineTo(x, camera.height+20);
+          g.closePath();
+          g.fill();
         }
         continue;
       }
       if(layer.type==='foreground'){
-        ctx.fillStyle=layer.color||'#1f3b5f';
-        ctx.fillRect(-offsetX, camera.height-(layer.height||140)+offsetY, camera.width+(layer.spacing||camera.width)*2, (layer.height||140)+40);
+        g.fillStyle=layer.color||'#1f3b5f';
+        g.fillRect(-offsetX, camera.height-(layer.height||140)+offsetY, camera.width+(layer.spacing||camera.width)*2, (layer.height||140)+40);
         continue;
       }
     }
@@ -591,50 +763,120 @@
   };
 
   function drawObstacle(ob){
-    const screenX=Math.round(ob.x-camera.x);
-    const screenY=Math.round(ob.y-camera.y);
-    ctx.fillStyle=OBSTACLE_COLORS[ob.type] || OBSTACLE_COLORS.default;
-    ctx.fillRect(screenX,screenY,ob.w,ob.h);
-    ctx.strokeStyle='#0f172a';
-    ctx.lineWidth=1;
-    ctx.strokeRect(screenX+0.5,screenY+0.5,ob.w-1,ob.h-1);
+    const g=Graphics.sceneCtx;
+    const screenX=snapPixel(ob.x-camera.x);
+    const screenY=snapPixel(ob.y-camera.y);
+    g.fillStyle=OBSTACLE_COLORS[ob.type] || OBSTACLE_COLORS.default;
+    g.fillRect(screenX,screenY,ob.w,ob.h);
+    g.strokeStyle='rgba(8,12,20,0.65)';
+    g.lineWidth=1;
+    g.strokeRect(screenX+0.5,screenY+0.5,ob.w-1,ob.h-1);
   }
 
   function drawProp(prop){
-    const x=Math.round(prop.x-camera.x);
-    const y=Math.round(prop.y-camera.y);
+    const g=Graphics.sceneCtx;
+    const x=snapPixel(prop.x-camera.x);
+    const y=snapPixel(prop.y-camera.y);
     const spriteEntry=prop.sprite;
+    if((prop.shadow ?? prop.height>0)){
+      const baseX=x+prop.w/2;
+      const baseY=y+prop.h;
+      const radiusX=Math.max(6,prop.w*0.45);
+      const radiusY=Math.max(3,(prop.height||prop.h*0.25)*0.25);
+      g.save();
+      g.fillStyle='rgba(10,12,20,0.4)';
+      g.beginPath();
+      g.ellipse(baseX,baseY,radiusX,radiusY,0,0,Math.PI*2);
+      g.fill();
+      g.restore();
+    }
+    const outlineColor=prop.outlineColor ?? Graphics.outlineColor;
+    const outlineThickness=prop.outlineThickness ?? Graphics.outlineThickness;
     if(spriteEntry && spriteEntry.ready){
-      ctx.drawImage(spriteEntry.img, x, y, prop.w, prop.h);
+      drawOutlinedSprite(g,spriteEntry.img,0,0,spriteEntry.img.width,spriteEntry.img.height,x,y,prop.w,prop.h,outlineColor,outlineThickness);
     } else {
-      ctx.fillStyle=prop.color || '#94a3b8';
-      ctx.fillRect(x,y,prop.w,prop.h);
-      ctx.strokeStyle='#1f2937';
-      ctx.strokeRect(x+0.5,y+0.5,prop.w-1,prop.h-1);
+      drawOutlinedRect(g,x,y,prop.w,prop.h,prop.color||'#94a3b8',outlineColor,outlineThickness);
       if(spriteEntry && spriteEntry.error){
-        ctx.strokeStyle='#ef4444';
-        ctx.beginPath();
-        ctx.moveTo(x+4,y+4);
-        ctx.lineTo(x+prop.w-4,y+prop.h-4);
-        ctx.moveTo(x+prop.w-4,y+4);
-        ctx.lineTo(x+4,y+prop.h-4);
-        ctx.stroke();
+        g.strokeStyle='#ef4444';
+        g.beginPath();
+        g.moveTo(x+4,y+4);
+        g.lineTo(x+prop.w-4,y+prop.h-4);
+        g.moveTo(x+prop.w-4,y+4);
+        g.lineTo(x+4,y+prop.h-4);
+        g.stroke();
       }
     }
   }
 
   function drawPlayer(){
+    const g=Graphics.sceneCtx;
     const px=player.x-camera.x;
     const py=player.y-camera.y;
     if(spriteReady){
       const {sx,sy,sw,sh}=frameRect(player.dir,player.frame);
-      ctx.drawImage(sprite, sx,sy,sw,sh, Math.round(px-sw/2), Math.round(py-sh/2), sw, sh);
+      const destX=px-sw/2;
+      const destY=py-sh/2;
+      drawOutlinedSprite(g,sprite,sx,sy,sw,sh,destX,destY,sw,sh,player.outlineColor||Graphics.outlineColor,player.outlineThickness||Graphics.outlineThickness);
     } else {
-      ctx.fillStyle="#e5e7eb";
-      ctx.beginPath();
-      ctx.arc(Math.round(px),Math.round(py),16,0,Math.PI*2);
-      ctx.fill();
+      drawOutlinedRect(g,px-16,py-16,32,32,'#e5e7eb');
     }
+  }
+
+  // ===== Particle effects (dust puffs on acceleration/braking) =====
+  function spawnDustBurst(count=3,dirX=0,dirY=0){
+    const originX=player.x;
+    const originY=player.y + (player.collider?.h||24)*0.35;
+    for(let i=0;i<count;i++){
+      const angle=Math.random()*Math.PI*2;
+      const speed=30+Math.random()*50;
+      const vx=Math.cos(angle)*speed + dirX*30;
+      const vy=Math.sin(angle)*speed + dirY*30;
+      particles.push({
+        x:originX+(Math.random()-0.5)*6,
+        y:originY+(Math.random()-0.5)*4,
+        vx,
+        vy,
+        life:0,
+        maxLife:0.35+Math.random()*0.2,
+        size:2.2+Math.random()*1.6
+      });
+    }
+  }
+
+  function updateParticles(dt){
+    for(let i=particles.length-1;i>=0;i--){
+      const p=particles[i];
+      p.life+=dt;
+      if(p.life>=p.maxLife){
+        particles.splice(i,1);
+        continue;
+      }
+      p.x+=p.vx*dt;
+      p.y+=p.vy*dt;
+      p.vx*=0.85;
+      p.vy*=0.85;
+    }
+  }
+
+  function drawParticles(){
+    if(!particles.length) return;
+    const g=Graphics.sceneCtx;
+    g.save();
+    g.globalCompositeOperation='lighter';
+    for(const p of particles){
+      const progress=p.life/p.maxLife;
+      const alpha=Math.max(0,0.55-progress*0.55);
+      if(alpha<=0) continue;
+      const screenX=p.x-camera.x;
+      const screenY=p.y-camera.y;
+      if(screenX<-20 || screenX>camera.width+20 || screenY<-20 || screenY>camera.height+20) continue;
+      const size=p.size*(1+progress*0.4);
+      g.fillStyle=`rgba(205,214,230,${alpha})`;
+      g.beginPath();
+      g.ellipse(screenX,screenY,size,size*0.6,0,0,Math.PI*2);
+      g.fill();
+    }
+    g.restore();
   }
 
   function drawWorld(){
@@ -655,9 +897,79 @@
     drawPlayer();
   }
 
+  // ===== Toon lighting pass =====
+  function celLighting(){
+    const g=Graphics.sceneCtx;
+    const lctx=Graphics.lightingCtx;
+    const width=camera.width;
+    const height=camera.height;
+    const ambient=Math.max(0,Math.min(1,Graphics.ambientDarkness));
+    const ambientBrightness=1-ambient;
+    const baseChannel=Math.round(ambientBrightness*255);
+    const toneLevels=(Graphics.toneLevels||[0,1]).slice().sort((a,b)=>a-b);
+
+    lctx.save();
+    lctx.globalCompositeOperation='source-over';
+    lctx.clearRect(0,0,width,height);
+    lctx.fillStyle=`rgb(${baseChannel},${baseChannel},${baseChannel})`;
+    lctx.fillRect(0,0,width,height);
+
+    const activeLights=[];
+    if(Array.isArray(Graphics.lights)) activeLights.push(...Graphics.lights);
+    if(Graphics.playerLightEnabled){
+      activeLights.push({
+        x:player.x,
+        y:player.y+(player.collider?.h||0)*0.35,
+        radius:Graphics.playerLightRadius,
+        intensity:Graphics.playerLightIntensity
+      });
+    }
+
+    for(const light of activeLights){
+      const radius=Math.max(4,Number(light.radius)||0);
+      const intensity=Math.max(0,Math.min(1,Number(light.intensity ?? 1)));
+      if(intensity<=0 || radius<=0) continue;
+      const cx=light.x-camera.x;
+      const cy=light.y-camera.y;
+      if(cx+radius< -100 || cy+radius< -100 || cx-radius>width+100 || cy-radius>height+100) continue;
+      const centerX=snapPixel(cx);
+      const centerY=snapPixel(cy);
+      for(let i=0;i<toneLevels.length;i++){
+        const level=Math.max(0,Math.min(1,toneLevels[i]));
+        const ratio=(toneLevels.length-i)/toneLevels.length;
+        let bandRadius=radius*ratio;
+        if(Graphics.pixelArtMode) bandRadius=Math.max(1,Math.round(bandRadius));
+        if(bandRadius<=0) continue;
+        const brightness=ambientBrightness + (1-ambientBrightness)*level*intensity;
+        const channel=Math.round(Math.max(ambientBrightness,Math.min(1,brightness))*255);
+        lctx.beginPath();
+        lctx.arc(centerX,centerY,bandRadius,0,Math.PI*2);
+        lctx.closePath();
+        lctx.fillStyle=`rgb(${channel},${channel},${channel})`;
+        lctx.fill();
+      }
+    }
+    lctx.restore();
+
+    g.save();
+    g.globalCompositeOperation='multiply';
+    g.drawImage(Graphics.lightingCanvas,0,0,width,height);
+    g.restore();
+    g.globalCompositeOperation='source-over';
+  }
+
   function draw(){
     drawParallaxLayers();
     drawWorld();
+    drawParticles();
+    celLighting();
+
+    ctx.save();
+    ctx.setTransform(1,0,0,1,0,0);
+    ctx.clearRect(0,0,gameC.width,gameC.height);
+    ctx.drawImage(Graphics.sceneCanvas,0,0,Graphics.sceneCanvas.width,Graphics.sceneCanvas.height,0,0,gameC.width,gameC.height);
+    ctx.restore();
+    ctx.setTransform(dpr,0,0,dpr,0,0);
   }
 
   let last=0;


### PR DESCRIPTION
## Summary
- add a configurable `Graphics` facade with helpers for outlines, lights, pixel-art snapping, and global render scale
- render world content to offscreen canvases, draw outlined props/player sprites, and apply a quantized cel-lighting multiply pass before compositing to screen
- support prop shadows, room-specified lights, and lightweight dust particle bursts when movement starts or stops

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cd06326a3483278bf54e7f5c4e0b90