### PR TITLE
Add Ultima-style bakery canvas demo with NPC AI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and provide your own keys.
+OPENAI_API_KEY=
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,868 @@
+{
+  "name": "ultima-bakery-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ultima-bakery-demo",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ultima-bakery-demo",
+  "version": "1.0.0",
+  "description": "Ultima-inspired bakery slice with Express server and canvas client.",
+  "main": "server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  }
+}

--- a/public/game.js
+++ b/public/game.js
@@ -1,0 +1,1013 @@
+// public/game.js - Tiny Ultima-like slice with a baker NPC and simple crafting.
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const hud = {
+  fps: document.getElementById('hud-fps'),
+  time: document.getElementById('hud-time'),
+  room: document.getElementById('hud-room'),
+  inventory: document.getElementById('hud-inventory')
+};
+
+const panel = {
+  root: document.getElementById('interaction-panel'),
+  title: document.getElementById('panel-title'),
+  body: document.getElementById('panel-body'),
+  actions: document.getElementById('panel-actions'),
+  dialogue: document.getElementById('panel-dialogue'),
+  talk: document.getElementById('panel-talk'),
+  close: document.getElementById('panel-close')
+};
+
+const outlineCanvas = document.createElement('canvas');
+const outlineCtx = outlineCanvas.getContext('2d');
+const lightCanvas = document.createElement('canvas');
+const lightCtx = lightCanvas.getContext('2d');
+
+const STATE = {
+  viewport: { width: window.innerWidth, height: window.innerHeight, dpr: window.devicePixelRatio || 1 },
+  assets: {},
+  rooms: [],
+  room: null,
+  player: null,
+  camera: { x: 0, y: 0, width: window.innerWidth, height: window.innerHeight },
+  keys: new Set(),
+  lastFrame: performance.now(),
+  fps: 0,
+  timeOfDay: 8.5,
+  timeRate: 0.25,
+  ambient: 0.4,
+  activeInteraction: null,
+  tempWaypoints: [],
+  worldFlags: {}
+};
+
+const ITEM_CATALOG = {
+  flour: { id: 'flour', name: 'Bag of Flour' },
+  water: { id: 'water', name: 'Bucket of Water' },
+  flourPile: { id: 'flourPile', name: 'Pile of Flour' },
+  dough: { id: 'dough', name: 'Bread Dough' },
+  loaf: { id: 'loaf', name: 'Fresh Loaf' }
+};
+
+const QUEST_CATALOG = {
+  bakers_helper: {
+    id: 'bakers_helper',
+    name: "Baker's Helper",
+    stages: ['Talk to Mera', 'Bake a loaf together', 'Deliver the bread']
+  },
+  morning_customers: {
+    id: 'morning_customers',
+    name: 'Morning Customers',
+    stages: ['Prepare stock', 'Serve the first guest']
+  }
+};
+
+// TODO: Drop hand-painted sprites into public/assets/** to replace these placeholders.
+const ASSET_MANIFEST = {
+  player: { path: 'assets/sprites/player.png', width: 56, height: 84, color: '#78b7ff', label: 'PLAYER' },
+  baker: { path: 'assets/sprites/baker.png', width: 56, height: 84, color: '#ff9cbc', label: 'BAKER' },
+  table: { path: 'assets/props/table.png', width: 140, height: 80, color: '#cba36e', label: 'TABLE' },
+  oven: { path: 'assets/props/oven.png', width: 110, height: 110, color: '#ffad62', label: 'OVEN' },
+  flour: { path: 'assets/props/flour.png', width: 90, height: 96, color: '#e5e0d6', label: 'FLOUR' },
+  barrel: { path: 'assets/props/barrel.png', width: 90, height: 96, color: '#6c8aa5', label: 'WATER' },
+  shelf: { path: 'assets/props/shelf.png', width: 160, height: 110, color: '#8c6f53', label: 'SHELF' }
+};
+
+function resizeCanvas() {
+  STATE.viewport.width = window.innerWidth;
+  STATE.viewport.height = window.innerHeight;
+  STATE.viewport.dpr = window.devicePixelRatio || 1;
+  canvas.width = STATE.viewport.width * STATE.viewport.dpr;
+  canvas.height = STATE.viewport.height * STATE.viewport.dpr;
+  canvas.style.width = `${STATE.viewport.width}px`;
+  canvas.style.height = `${STATE.viewport.height}px`;
+  ctx.setTransform(STATE.viewport.dpr, 0, 0, STATE.viewport.dpr, 0, 0);
+  lightCanvas.width = canvas.width;
+  lightCanvas.height = canvas.height;
+  lightCtx.setTransform(STATE.viewport.dpr, 0, 0, STATE.viewport.dpr, 0, 0);
+  if (STATE.camera) {
+    STATE.camera.width = STATE.viewport.width;
+    STATE.camera.height = STATE.viewport.height;
+  }
+}
+
+window.addEventListener('resize', resizeCanvas);
+
+async function loadAssets() {
+  const entries = await Promise.all(
+    Object.entries(ASSET_MANIFEST).map(async ([key, def]) => {
+      const image = await loadSprite(def).catch(() => createPlaceholder(def));
+      return [key, image];
+    })
+  );
+  return Object.fromEntries(entries);
+}
+function loadSprite(def) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => {
+      console.warn(`Missing asset ${def.path}, using placeholder.`);
+      resolve(createPlaceholder(def));
+    };
+    img.src = def.path;
+    setTimeout(() => {
+      if (!img.complete) {
+        resolve(createPlaceholder(def));
+      }
+    }, 1500);
+  });
+}
+
+function createPlaceholder(def) {
+  const c = document.createElement('canvas');
+  c.width = def.width;
+  c.height = def.height;
+  const cctx = c.getContext('2d');
+  cctx.fillStyle = def.color;
+  cctx.fillRect(0, 0, c.width, c.height);
+  cctx.strokeStyle = 'rgba(0,0,0,0.4)';
+  cctx.lineWidth = 4;
+  cctx.strokeRect(2, 2, c.width - 4, c.height - 4);
+  cctx.fillStyle = 'rgba(0,0,0,0.6)';
+  cctx.font = 'bold 12px sans-serif';
+  cctx.textAlign = 'center';
+  cctx.textBaseline = 'middle';
+  cctx.fillText(def.label, c.width / 2, c.height / 2);
+  return c;
+}
+
+function setupInput() {
+  window.addEventListener('keydown', (event) => {
+    const key = event.key.toLowerCase();
+    if (['w', 'a', 's', 'd'].includes(key)) {
+      STATE.keys.add(key);
+      event.preventDefault();
+    }
+    if (key === 'e') {
+      event.preventDefault();
+      attemptInteract();
+    }
+  });
+  window.addEventListener('keyup', (event) => {
+    STATE.keys.delete(event.key.toLowerCase());
+  });
+
+  panel.close.addEventListener('click', () => {
+    STATE.activeInteraction = null;
+    refreshPanel();
+  });
+
+  panel.talk.addEventListener('click', () => {
+    if (STATE.activeInteraction?.kind === 'npc') {
+      talkToNpc(STATE.activeInteraction.target);
+    }
+  });
+}
+
+function initWorld(assets) {
+  STATE.assets = assets;
+  const room = {
+    id: 'bakery',
+    name: 'Bakery Kitchen',
+    width: 1600,
+    height: 1200,
+    props: [],
+    npcs: [],
+    obstacles: []
+  };
+
+  const oven = {
+    id: 'stone_oven',
+    name: 'Stone Oven',
+    kind: 'prop',
+    x: 990,
+    y: 520,
+    width: 120,
+    height: 120,
+    sprite: assets.oven,
+    solid: true,
+    state: 'idle',
+    timer: 0
+  };
+
+  const table = {
+    id: 'prep_table',
+    name: 'Preparation Table',
+    kind: 'prop',
+    x: 780,
+    y: 600,
+    width: 140,
+    height: 86,
+    sprite: assets.table,
+    solid: true,
+    state: 'empty'
+  };
+
+  const flourSacks = {
+    id: 'flour_sacks',
+    name: 'Flour Sacks',
+    kind: 'prop',
+    x: 620,
+    y: 520,
+    width: 110,
+    height: 120,
+    sprite: assets.flour,
+    solid: true,
+    resource: 'flour'
+  };
+
+  const waterBarrel = {
+    id: 'water_barrel',
+    name: 'Water Barrel',
+    kind: 'prop',
+    x: 620,
+    y: 720,
+    width: 110,
+    height: 120,
+    sprite: assets.barrel,
+    solid: true,
+    resource: 'water'
+  };
+
+  const shelf = {
+    id: 'spice_shelf',
+    name: 'Spice Shelf',
+    kind: 'prop',
+    x: 1080,
+    y: 640,
+    width: 150,
+    height: 110,
+    sprite: assets.shelf,
+    solid: true
+  };
+
+  room.props.push(oven, table, flourSacks, waterBarrel, shelf);
+
+  const baker = {
+    id: 'npc_mera',
+    name: 'Mera the Baker',
+    kind: 'npc',
+    x: 900,
+    y: 680,
+    width: 56,
+    height: 84,
+    sprite: assets.baker,
+    solid: true,
+    profile: 'Village baker. Warm, practical, expects honest effort.',
+    memory: 'Met the new helper this morning.',
+    log: []
+  };
+
+  room.npcs.push(baker);
+
+  room.obstacles.push(
+    { x: 520, y: 480, width: 420, height: 40 },
+    { x: 520, y: 860, width: 460, height: 40 },
+    { x: 520, y: 480, width: 40, height: 420 },
+    { x: 940, y: 480, width: 40, height: 420 },
+    { x: 520, y: 900, width: 540, height: 40 },
+    { x: 520, y: 440, width: 540, height: 40 }
+  );
+
+  STATE.rooms = [room];
+  STATE.room = room;
+  STATE.player = {
+    name: 'Avatar',
+    x: 820,
+    y: 760,
+    width: 56,
+    height: 84,
+    speed: 220,
+    inventory: ['flour', 'water'],
+    quests: [],
+    facing: 'south'
+  };
+
+  STATE.camera.x = STATE.player.x - STATE.viewport.width / 2;
+  STATE.camera.y = STATE.player.y - STATE.viewport.height / 2;
+  STATE.camera.width = STATE.viewport.width;
+  STATE.camera.height = STATE.viewport.height;
+  room.oven = oven;
+  room.table = table;
+
+  updateHud();
+  refreshPanel();
+}
+function attemptInteract() {
+  const target = findInteractable();
+  if (!target) {
+    STATE.activeInteraction = null;
+    refreshPanel();
+    return;
+  }
+  if (STATE.activeInteraction && STATE.activeInteraction.target === target) {
+    STATE.activeInteraction = null;
+  } else {
+    STATE.activeInteraction = {
+      target,
+      kind: target.kind,
+      lastDialogue: target.kind === 'npc' ? 'Mera dusts flour off her hands.' : ''
+    };
+  }
+  refreshPanel();
+}
+
+function findInteractable() {
+  if (!STATE.room) return null;
+  const px = STATE.player.x + STATE.player.width / 2;
+  const py = STATE.player.y + STATE.player.height / 2;
+  let best = null;
+  let bestDist = Infinity;
+  const consider = [...STATE.room.props, ...STATE.room.npcs];
+  for (const target of consider) {
+    const tx = target.x + target.width / 2;
+    const ty = target.y + target.height / 2;
+    const dist = Math.hypot(px - tx, py - ty);
+    if (dist < 150 && dist < bestDist) {
+      best = target;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+function refreshPanel() {
+  const interaction = STATE.activeInteraction;
+  if (!interaction) {
+    panel.root.hidden = true;
+    return;
+  }
+
+  const target = interaction.target;
+  panel.root.hidden = false;
+  panel.title.textContent = target.name;
+  panel.body.textContent = describeTarget(target);
+  panel.dialogue.textContent = interaction.lastDialogue || '';
+  panel.actions.innerHTML = '';
+
+  const actions = buildActions(target);
+  actions.forEach((action) => {
+    const button = document.createElement('button');
+    button.textContent = action.label;
+    button.addEventListener('click', () => {
+      action.handler();
+      refreshPanel();
+      updateHud();
+    });
+    panel.actions.appendChild(button);
+  });
+
+  if (interaction.kind === 'npc') {
+    panel.talk.disabled = false;
+    panel.talk.style.display = 'inline-flex';
+  } else {
+    panel.talk.style.display = 'none';
+  }
+}
+
+function describeTarget(target) {
+  if (target.kind === 'npc') {
+    return 'A cheerful baker with flour on her sleeves. Maybe she has advice.';
+  }
+  if (target.id === 'prep_table') {
+    return `Prep table — current state: ${target.state === 'empty' ? 'clean' : target.state === 'flourPile' ? 'flour ready' : 'soft dough'}.`;
+  }
+  if (target.id === 'stone_oven') {
+    const status = target.state === 'idle' ? 'idle hearth' : target.state === 'baking' ? 'baking dough' : 'ready loaf!';
+    return `Stone oven • ${status}.`;
+  }
+  if (target.resource === 'flour') {
+    return 'Sacks of flour stacked and waiting to be scooped.';
+  }
+  if (target.resource === 'water') {
+    return 'A chilled barrel filled with fresh well water.';
+  }
+  return 'Wooden furniture adds warmth to the kitchen.';
+}
+
+function buildActions(target) {
+  const actions = [];
+  if (target.kind === 'npc') {
+    actions.push({
+      label: 'Trade Loaf',
+      handler: () => {
+        if (removeItem('loaf')) {
+          addMessage('You hand Mera a loaf. She promises to pay later.');
+          addQuestProgress('morning_customers', 2);
+          STATE.activeInteraction.lastDialogue = 'Thank you! I will sell this at the stall.';
+        } else {
+          STATE.activeInteraction.lastDialogue = 'Bring me a fresh loaf and I will gladly buy it.';
+        }
+      }
+    });
+    return actions;
+  }
+
+  if (target.id === 'prep_table') {
+    if (playerHas('flour') && target.state === 'empty') {
+      actions.push({
+        label: 'Sprinkle Flour',
+        handler: () => {
+          removeItem('flour');
+          target.state = 'flourPile';
+          addMessage('You spread flour across the table.');
+        }
+      });
+    }
+    if (playerHas('water') && target.state === 'flourPile') {
+      actions.push({
+        label: 'Add Water',
+        handler: () => {
+          removeItem('water');
+          target.state = 'dough';
+          addMessage('You knead the flour and water into dough.');
+        }
+      });
+    }
+    if (target.state === 'dough') {
+      actions.push({
+        label: 'Collect Dough',
+        handler: () => {
+          target.state = 'empty';
+          addItem('dough');
+          addMessage('Fresh dough rests in your satchel.');
+        }
+      });
+    }
+  }
+
+  if (target.id === 'stone_oven') {
+    if (playerHas('dough') && target.state === 'idle') {
+      actions.push({
+        label: 'Load Dough',
+        handler: () => {
+          removeItem('dough');
+          target.state = 'baking';
+          target.timer = 4.5;
+          addMessage('You slide the dough into the glowing oven.');
+        }
+      });
+    }
+    if (target.state === 'baking') {
+      actions.push({
+        label: 'Peek Inside',
+        handler: () => {
+          STATE.activeInteraction.lastDialogue = 'The dough is rising. Give it another moment.';
+        }
+      });
+    }
+    if (target.state === 'ready') {
+      actions.push({
+        label: 'Take Loaf',
+        handler: () => {
+          target.state = 'idle';
+          target.timer = 0;
+          addItem('loaf');
+          addQuestProgress('bakers_helper', 2);
+          addMessage('You lift a golden loaf from the oven.');
+        }
+      });
+    }
+  }
+
+  if (target.resource === 'flour') {
+    actions.push({
+      label: 'Scoop Flour',
+      handler: () => {
+        addItem('flour');
+        addMessage('You scoop a bag of flour.');
+      }
+    });
+  }
+  if (target.resource === 'water') {
+    actions.push({
+      label: 'Draw Water',
+      handler: () => {
+        addItem('water');
+        addMessage('You draw a bucket of cool water.');
+      }
+    });
+  }
+
+  return actions;
+}
+function playerHas(itemId) {
+  return STATE.player.inventory.includes(itemId);
+}
+
+function addItem(itemId) {
+  STATE.player.inventory.push(itemId);
+}
+
+function removeItem(itemId) {
+  const index = STATE.player.inventory.indexOf(itemId);
+  if (index !== -1) {
+    STATE.player.inventory.splice(index, 1);
+    return true;
+  }
+  return false;
+}
+
+function addQuestProgress(questId, stage) {
+  const existing = STATE.player.quests.find((q) => q.id === questId);
+  if (!existing) {
+    STATE.player.quests.push({ id: questId, stage: stage || 1 });
+    return;
+  }
+  if (stage && stage > existing.stage) {
+    existing.stage = stage;
+  }
+}
+
+function addMessage(text) {
+  panel.dialogue.textContent = text;
+}
+
+async function talkToNpc(npc) {
+  const snapshot = buildSnapshot(npc);
+  panel.talk.disabled = true;
+  panel.dialogue.textContent = 'Consulting the guild of bakers...';
+  try {
+    const response = await fetch('/npc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(snapshot)
+    });
+    const text = await response.text();
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch (err) {
+      console.error('NPC JSON parse error', text);
+      panel.dialogue.textContent = '⚠️ The baker mutters nonsense (invalid JSON).';
+      return;
+    }
+    if (payload.error) {
+      panel.dialogue.textContent = `⚠️ ${payload.error}`;
+      return;
+    }
+    if (!validateNpcPayload(payload)) {
+      panel.dialogue.textContent = '⚠️ The baker pauses; her reply made no sense.';
+      return;
+    }
+    npc.log.push(payload.dialogue);
+    if (npc.log.length > 4) npc.log.shift();
+    npc.memory = npc.log.join(' | ').slice(-180);
+    STATE.activeInteraction.lastDialogue = payload.dialogue;
+    handleNpcActions(payload.actions, npc);
+    panel.dialogue.textContent = payload.dialogue;
+  } catch (err) {
+    console.error(err);
+    panel.dialogue.textContent = '⚠️ The wind drowns out her words (network error).';
+  } finally {
+    panel.talk.disabled = false;
+  }
+}
+
+function validateNpcPayload(payload) {
+  return payload && typeof payload.dialogue === 'string' && Array.isArray(payload.actions);
+}
+
+function handleNpcActions(actions, npc) {
+  actions.forEach((action) => {
+    switch (action.type) {
+      case 'set_flag':
+        if (action.flag) {
+          STATE.worldFlags[action.flag] = action.value ?? true;
+        }
+        break;
+      case 'give_item':
+        if (action.item_id && ITEM_CATALOG[action.item_id]) {
+          addItem(action.item_id);
+          panel.dialogue.textContent += `\nReceived ${ITEM_CATALOG[action.item_id].name}.`;
+        }
+        break;
+      case 'start_quest':
+        if (action.quest_id) {
+          addQuestProgress(action.quest_id, action.stage || 1);
+        }
+        break;
+      case 'advance_quest':
+        if (action.quest_id) {
+          addQuestProgress(action.quest_id, action.stage || 2);
+        }
+        break;
+      case 'set_waypoint':
+        if (typeof action.x === 'number' && typeof action.y === 'number') {
+          STATE.tempWaypoints.push({
+            x: action.x,
+            y: action.y,
+            label: action.label || 'Waypoint',
+            timer: 8
+          });
+        }
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+function buildSnapshot(npc) {
+  const room = STATE.room;
+  const oven = room.oven;
+  return {
+    npc_id: npc.id,
+    npc_profile: npc.profile,
+    npc_memory: npc.memory,
+    player_state: {
+      name: STATE.player.name,
+      inventory: [...STATE.player.inventory]
+    },
+    location: {
+      room: room.name,
+      player: { x: Math.round(STATE.player.x), y: Math.round(STATE.player.y) },
+      oven_status: oven.state
+    },
+    time_of_day: Number(STATE.timeOfDay.toFixed(2)),
+    active_quests: STATE.player.quests.map((q) => ({ id: q.id, stage: q.stage }))
+  };
+}
+
+function update(dt) {
+  if (!STATE.room) return;
+  updateTimeOfDay(dt);
+  updatePlayer(dt);
+  updateOven(dt);
+  updateCamera();
+  updateWaypoints(dt);
+  updateHud();
+}
+
+function updateTimeOfDay(dt) {
+  STATE.timeOfDay = (STATE.timeOfDay + dt * STATE.timeRate) % 24;
+  const daylight = (Math.sin(((STATE.timeOfDay - 6) / 24) * Math.PI * 2) + 1) / 2;
+  STATE.ambient = 0.25 + (1 - daylight) * 0.55;
+}
+
+function updatePlayer(dt) {
+  const speed = STATE.player.speed;
+  let vx = 0;
+  let vy = 0;
+  if (STATE.keys.has('w')) vy -= 1;
+  if (STATE.keys.has('s')) vy += 1;
+  if (STATE.keys.has('a')) vx -= 1;
+  if (STATE.keys.has('d')) vx += 1;
+  if (vx || vy) {
+    const length = Math.hypot(vx, vy) || 1;
+    vx = (vx / length) * speed * dt;
+    vy = (vy / length) * speed * dt;
+    moveWithCollision(STATE.player, vx, vy);
+    if (Math.abs(vx) > Math.abs(vy)) {
+      STATE.player.facing = vx > 0 ? 'east' : 'west';
+    } else {
+      STATE.player.facing = vy > 0 ? 'south' : 'north';
+    }
+  }
+}
+
+function updateOven(dt) {
+  const oven = STATE.room.oven;
+  if (oven.state === 'baking') {
+    oven.timer -= dt;
+    if (oven.timer <= 0) {
+      oven.state = 'ready';
+      oven.timer = 0;
+      addMessage('The loaf is ready!');
+    }
+  }
+  STATE.worldFlags.oven_status = oven.state;
+}
+
+function moveWithCollision(entity, dx, dy) {
+  const room = STATE.room;
+  const colliders = [...room.obstacles, ...room.props.filter((p) => p.solid), ...room.npcs.filter((n) => n.solid)];
+
+  entity.x += dx;
+  if (colliders.some((col) => col !== entity && rectsOverlap(entity, col))) {
+    entity.x -= dx;
+  }
+
+  entity.y += dy;
+  if (colliders.some((col) => col !== entity && rectsOverlap(entity, col))) {
+    entity.y -= dy;
+  }
+
+  entity.x = clamp(entity.x, 480, room.width - entity.width - 200);
+  entity.y = clamp(entity.y, 460, room.height - entity.height - 220);
+}
+
+function updateCamera() {
+  const camera = STATE.camera;
+  const player = STATE.player;
+  const room = STATE.room;
+  const deadzoneWidth = camera.width * 0.3;
+  const deadzoneHeight = camera.height * 0.35;
+  const dzLeft = camera.x + (camera.width - deadzoneWidth) / 2;
+  const dzRight = dzLeft + deadzoneWidth;
+  const dzTop = camera.y + (camera.height - deadzoneHeight) / 2;
+  const dzBottom = dzTop + deadzoneHeight;
+  const px = player.x + player.width / 2;
+  const py = player.y + player.height / 2;
+
+  if (px < dzLeft) camera.x -= dzLeft - px;
+  if (px > dzRight) camera.x += px - dzRight;
+  if (py < dzTop) camera.y -= dzTop - py;
+  if (py > dzBottom) camera.y += py - dzBottom;
+
+  camera.x = clamp(camera.x, 480 - camera.width / 2, room.width - camera.width - 200);
+  camera.y = clamp(camera.y, 440 - camera.height / 2, room.height - camera.height - 200);
+}
+function updateWaypoints(dt) {
+  STATE.tempWaypoints = STATE.tempWaypoints.filter((waypoint) => {
+    waypoint.timer -= dt;
+    return waypoint.timer > 0;
+  });
+}
+
+function rectsOverlap(a, b) {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function updateHud() {
+  hud.fps.textContent = STATE.fps.toFixed(0);
+  hud.time.textContent = describeTimeOfDay(STATE.timeOfDay);
+  hud.room.textContent = STATE.room ? STATE.room.name : '--';
+  hud.inventory.textContent = STATE.player.inventory
+    .map((id) => ITEM_CATALOG[id]?.name || id)
+    .join(', ') || 'Empty';
+}
+
+function describeTimeOfDay(time) {
+  const hour = Math.floor(time);
+  const minute = Math.floor((time % 1) * 60);
+  const suffix = hour < 12 ? 'AM' : 'PM';
+  const label = hour < 5 ? 'Night' : hour < 8 ? 'Dawn' : hour < 12 ? 'Morning' : hour < 17 ? 'Day' : hour < 21 ? 'Evening' : 'Late';
+  const displayHour = ((hour + 11) % 12) + 1;
+  return `${label} ${displayHour}:${minute.toString().padStart(2, '0')} ${suffix}`;
+}
+
+function draw() {
+  if (!STATE.room) return;
+  ctx.save();
+  ctx.clearRect(0, 0, STATE.viewport.width, STATE.viewport.height);
+  drawBackground();
+  drawWorld();
+  drawWaypoints();
+  applyLighting();
+  ctx.restore();
+}
+
+function drawBackground() {
+  const camera = STATE.camera;
+  const tile = 80;
+  const startX = Math.floor(camera.x / tile) * tile;
+  const startY = Math.floor(camera.y / tile) * tile;
+  const cols = Math.ceil(STATE.viewport.width / tile) + 2;
+  const rows = Math.ceil(STATE.viewport.height / tile) + 2;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const worldX = startX + x * tile;
+      const worldY = startY + y * tile;
+      const screenX = worldX - camera.x;
+      const screenY = worldY - camera.y;
+      const shade = (x + y) % 2 === 0 ? '#3b2d2a' : '#342621';
+      ctx.fillStyle = shade;
+      ctx.fillRect(screenX, screenY, tile, tile);
+    }
+  }
+}
+
+function drawWorld() {
+  const camera = STATE.camera;
+  const room = STATE.room;
+  const renderables = [];
+  room.props.forEach((prop) => renderables.push({ entity: prop, order: prop.y + prop.height }));
+  room.npcs.forEach((npc) => renderables.push({ entity: npc, order: npc.y + npc.height }));
+  renderables.push({ entity: STATE.player, order: STATE.player.y + STATE.player.height });
+  renderables.sort((a, b) => a.order - b.order);
+
+  renderables.forEach(({ entity }) => {
+    const screenX = Math.round(entity.x - camera.x);
+    const screenY = Math.round(entity.y - camera.y);
+    drawEntity(entity, screenX, screenY);
+  });
+}
+
+function drawEntity(entity, screenX, screenY) {
+  const width = entity.width;
+  const height = entity.height;
+  const sprite = entity.sprite;
+  drawWithOutline((bufferCtx) => {
+    if (sprite) {
+      bufferCtx.drawImage(sprite, 0, 0, width, height);
+    } else {
+      bufferCtx.fillStyle = '#888';
+      bufferCtx.fillRect(0, 0, width, height);
+    }
+    if (entity.id === 'prep_table') {
+      if (entity.state === 'flourPile') {
+        bufferCtx.fillStyle = 'rgba(245, 236, 210, 0.9)';
+        bufferCtx.fillRect(width * 0.2, height * 0.45, width * 0.6, height * 0.15);
+      }
+      if (entity.state === 'dough') {
+        bufferCtx.fillStyle = 'rgba(214, 165, 120, 0.95)';
+        bufferCtx.beginPath();
+        bufferCtx.ellipse(width / 2, height * 0.55, width * 0.3, height * 0.18, 0, 0, Math.PI * 2);
+        bufferCtx.fill();
+      }
+    }
+    if (entity.id === 'stone_oven' && entity.state === 'ready') {
+      bufferCtx.fillStyle = 'rgba(255, 215, 160, 0.7)';
+      bufferCtx.fillRect(width * 0.35, height * 0.55, width * 0.3, height * 0.18);
+    }
+  }, screenX, screenY, width, height);
+}
+
+function drawWithOutline(drawBody, x, y, width, height) {
+  const pad = 4;
+  outlineCanvas.width = width + pad;
+  outlineCanvas.height = height + pad;
+  outlineCtx.setTransform(1, 0, 0, 1, 0, 0);
+  outlineCtx.clearRect(0, 0, outlineCanvas.width, outlineCanvas.height);
+
+  const offsets = [
+    [0, pad / 2],
+    [pad, pad / 2],
+    [pad / 2, 0],
+    [pad / 2, pad],
+    [1, 1],
+    [pad - 1, 1],
+    [1, pad - 1],
+    [pad - 1, pad - 1]
+  ];
+
+  outlineCtx.save();
+  outlineCtx.filter = 'brightness(0%)';
+  offsets.forEach(([ox, oy]) => {
+    outlineCtx.save();
+    outlineCtx.translate(ox, oy);
+    drawBody(outlineCtx);
+    outlineCtx.restore();
+  });
+  outlineCtx.restore();
+
+  outlineCtx.globalCompositeOperation = 'source-in';
+  outlineCtx.fillStyle = 'rgba(10, 12, 30, 0.9)';
+  outlineCtx.fillRect(0, 0, outlineCanvas.width, outlineCanvas.height);
+  outlineCtx.globalCompositeOperation = 'source-over';
+  outlineCtx.save();
+  outlineCtx.translate(pad / 2, pad / 2);
+  drawBody(outlineCtx);
+  outlineCtx.restore();
+
+  ctx.drawImage(outlineCanvas, x - pad / 2, y - pad / 2);
+}
+
+function drawWaypoints() {
+  const camera = STATE.camera;
+  ctx.save();
+  ctx.lineWidth = 2;
+  STATE.tempWaypoints.forEach((wp) => {
+    const sx = wp.x - camera.x;
+    const sy = wp.y - camera.y;
+    ctx.strokeStyle = 'rgba(120, 200, 255, 0.9)';
+    ctx.beginPath();
+    ctx.moveTo(sx - 10, sy);
+    ctx.lineTo(sx, sy - 14);
+    ctx.lineTo(sx + 10, sy);
+    ctx.lineTo(sx, sy + 14);
+    ctx.closePath();
+    ctx.stroke();
+    ctx.fillStyle = 'rgba(120, 200, 255, 0.3)';
+    ctx.fill();
+    ctx.fillStyle = 'rgba(200, 240, 255, 0.9)';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(wp.label, sx, sy + 26);
+  });
+  ctx.restore();
+}
+
+function applyLighting() {
+  const camera = STATE.camera;
+  const lights = buildLights();
+  const { width, height, dpr } = STATE.viewport;
+  lightCanvas.width = width * dpr;
+  lightCanvas.height = height * dpr;
+  lightCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  lightCtx.clearRect(0, 0, width, height);
+  lightCtx.globalCompositeOperation = 'source-over';
+  lightCtx.fillStyle = `rgba(6, 8, 16, ${STATE.ambient})`;
+  lightCtx.fillRect(0, 0, width, height);
+  lightCtx.globalCompositeOperation = 'destination-out';
+
+  lights.forEach((light) => {
+    const radius = light.radius;
+    for (let step = 3; step >= 1; step--) {
+      lightCtx.globalAlpha = step === 3 ? 0.35 : step === 2 ? 0.55 : 0.85;
+      lightCtx.beginPath();
+      lightCtx.arc(
+        light.x - camera.x,
+        light.y - camera.y,
+        (radius * step) / 3,
+        0,
+        Math.PI * 2
+      );
+      lightCtx.fill();
+    }
+  });
+  lightCtx.globalAlpha = 1;
+  lightCtx.globalCompositeOperation = 'source-over';
+
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.drawImage(lightCanvas, 0, 0);
+  ctx.restore();
+
+  ctx.save();
+  lights.forEach((light) => {
+    const sx = light.x - camera.x;
+    const sy = light.y - camera.y;
+    const gradient = ctx.createRadialGradient(
+      sx,
+      sy,
+      0,
+      sx,
+      sy,
+      light.radius * 0.6
+    );
+    gradient.addColorStop(0, light.color);
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = gradient;
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.beginPath();
+    ctx.arc(sx, sy, light.radius * 0.6, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+function buildLights() {
+  const oven = STATE.room.oven;
+  const lights = [
+    {
+      x: oven.x + oven.width / 2,
+      y: oven.y + oven.height * 0.6,
+      radius: oven.state === 'baking' ? 260 : 200,
+      color: 'rgba(255, 180, 110, 0.55)'
+    },
+    {
+      x: STATE.player.x + STATE.player.width / 2,
+      y: STATE.player.y + STATE.player.height / 2,
+      radius: 180,
+      color: 'rgba(150, 200, 255, 0.2)'
+    }
+  ];
+  STATE.room.npcs.forEach((npc) => {
+    lights.push({
+      x: npc.x + npc.width / 2,
+      y: npc.y + npc.height / 2,
+      radius: 150,
+      color: 'rgba(255, 190, 150, 0.25)'
+    });
+  });
+  return lights;
+}
+
+function gameLoop(now) {
+  const dt = Math.min((now - STATE.lastFrame) / 1000, 0.1);
+  STATE.lastFrame = now;
+  STATE.fps = STATE.fps * 0.92 + (1 / dt) * 0.08;
+  update(dt);
+  draw();
+  requestAnimationFrame(gameLoop);
+}
+
+async function start() {
+  resizeCanvas();
+  ctx.fillStyle = '#111';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#fff';
+  ctx.font = '16px sans-serif';
+  ctx.fillText('Loading bakery...', 24, 36);
+  const assets = await loadAssets();
+  setupInput();
+  initWorld(assets);
+  STATE.lastFrame = performance.now();
+  requestAnimationFrame(gameLoop);
+}
+
+start();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Village Bakery Slice</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: 'Trebuchet MS', 'Lucida Sans Unicode', sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(circle at 30% 20%, #1e2335, #07090f 70%);
+        overflow: hidden;
+      }
+      canvas {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+        image-rendering: pixelated;
+        image-rendering: crisp-edges;
+      }
+      #hud {
+        position: fixed;
+        top: 12px;
+        left: 12px;
+        padding: 8px 12px;
+        background: rgba(10, 13, 22, 0.6);
+        border: 1px solid rgba(128, 170, 255, 0.2);
+        border-radius: 6px;
+        color: #d7e0ff;
+        min-width: 180px;
+        font-size: 12px;
+        backdrop-filter: blur(3px);
+      }
+      #hud strong {
+        color: #f0f6ff;
+      }
+      #interaction-panel {
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        width: 280px;
+        max-height: 60vh;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 12px;
+        background: rgba(14, 18, 28, 0.85);
+        border: 1px solid rgba(150, 110, 66, 0.4);
+        border-radius: 8px;
+        color: #f6e4c4;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(6px);
+      }
+      #interaction-panel[hidden] {
+        display: none;
+      }
+      #panel-title {
+        margin: 0;
+        font-size: 16px;
+        color: #ffdd9c;
+        text-shadow: 0 0 6px rgba(255, 200, 120, 0.3);
+      }
+      #panel-body {
+        font-size: 13px;
+        line-height: 1.3;
+        color: #f2d8b0;
+      }
+      #panel-dialogue {
+        font-size: 12px;
+        padding: 8px;
+        border-radius: 6px;
+        background: rgba(30, 25, 20, 0.6);
+        border: 1px solid rgba(255, 214, 153, 0.18);
+        min-height: 60px;
+        white-space: pre-wrap;
+      }
+      #panel-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      button {
+        appearance: none;
+        border: 1px solid rgba(240, 208, 150, 0.35);
+        border-radius: 4px;
+        padding: 6px 10px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: linear-gradient(135deg, rgba(255, 206, 128, 0.2), rgba(140, 90, 40, 0.2));
+        color: #ffe7c7;
+        cursor: pointer;
+      }
+      button:hover {
+        background: linear-gradient(135deg, rgba(255, 206, 128, 0.3), rgba(180, 120, 60, 0.35));
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="640" height="360"></canvas>
+    <section id="hud">
+      <div><strong>FPS:</strong> <span id="hud-fps">--</span></div>
+      <div><strong>Time:</strong> <span id="hud-time">Dawn</span></div>
+      <div><strong>Room:</strong> <span id="hud-room">--</span></div>
+      <div><strong>Inventory:</strong> <span id="hud-inventory">--</span></div>
+    </section>
+    <aside id="interaction-panel" hidden>
+      <h2 id="panel-title"></h2>
+      <div id="panel-body"></div>
+      <div id="panel-actions"></div>
+      <div id="panel-dialogue"></div>
+      <div style="display: flex; gap: 6px; justify-content: flex-end;">
+        <button id="panel-talk">Talk</button>
+        <button id="panel-close">Close</button>
+      </div>
+    </aside>
+    <script type="module" src="game.js"></script>
+  </body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,187 @@
+// server.js - Express server that proxies NPC dialogue to OpenAI or a local mock.
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+const path = require('path');
+
+// Node 18 exposes fetch globally; keep a tiny fallback for older runtimes.
+const fetchFn = global.fetch || ((...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args)));
+
+dotenv.config();
+
+const app = express();
+const PORT = Number(process.env.PORT || 3000);
+
+const ITEM_CATALOG = [
+  { id: 'flour', name: 'Bag of Flour' },
+  { id: 'water', name: 'Bucket of Water' },
+  { id: 'flourPile', name: 'Pile of Flour' },
+  { id: 'dough', name: 'Bread Dough' },
+  { id: 'loaf', name: 'Fresh Loaf' }
+];
+
+const QUEST_CATALOG = [
+  {
+    id: 'bakers_helper',
+    name: "Baker's Helper",
+    stages: ['Ask the baker about work.', 'Bake a loaf together.', 'Deliver the bread.']
+  },
+  {
+    id: 'morning_customers',
+    name: 'Morning Customers',
+    stages: ['Prepare stock for the stall.', 'Sell a loaf to the first guest.']
+  }
+];
+
+const ALLOWED_ACTIONS = ['set_flag', 'give_item', 'start_quest', 'advance_quest', 'set_waypoint'];
+
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/npc', async (req, res) => {
+  const snapshot = req.body;
+  if (!snapshot || typeof snapshot !== 'object' || !snapshot.npc_id) {
+    return res.status(400).json({ error: 'Invalid snapshot payload.' });
+  }
+
+  try {
+    let payload;
+    if (!process.env.OPENAI_API_KEY) {
+      payload = buildMockResponse(snapshot);
+    } else {
+      payload = await callOpenAI(snapshot);
+    }
+
+    if (!isValidPayload(payload)) {
+      throw new Error('Model returned an unexpected structure.');
+    }
+
+    res.json(payload);
+  } catch (err) {
+    console.error('Dialogue error:', err.message);
+    res.status(500).json({ error: 'Failed to prepare dialogue.' });
+  }
+});
+
+function isValidPayload(payload) {
+  if (!payload || typeof payload.dialogue !== 'string' || !Array.isArray(payload.actions)) {
+    return false;
+  }
+  return payload.actions.every((action) => action && ALLOWED_ACTIONS.includes(action.type));
+}
+
+function buildSystemPrompt(snapshot) {
+  return [
+    'You are Mera the village baker in a cozy Ultima-like town.',
+    'Stay in character, be kind, and keep answers short (<=70 words).',
+    'Never invent new mechanics, items, or quests.',
+    'Known items: ' + JSON.stringify(ITEM_CATALOG) + '.',
+    'Known quests: ' + JSON.stringify(QUEST_CATALOG) + '.',
+    'Allowed actions: ' + ALLOWED_ACTIONS.join(', ') + '.',
+    'Only respond with JSON shaped like the provided schema. No prose.'
+  ].join(' ');
+}
+
+function buildSchema() {
+  return {
+    name: 'npc_dialogue_turn',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        dialogue: { type: 'string' },
+        actions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: true,
+            properties: {
+              type: { type: 'string', enum: ALLOWED_ACTIONS }
+            },
+            required: ['type']
+          }
+        }
+      },
+      required: ['dialogue', 'actions']
+    }
+  };
+}
+
+async function callOpenAI(snapshot) {
+  const response = await fetchFn('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4.1-mini',
+      input: [
+        {
+          role: 'system',
+          content: [{ type: 'text', text: buildSystemPrompt(snapshot) }]
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: JSON.stringify(snapshot) }]
+        }
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: buildSchema()
+      }
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI error: ${response.status} ${text}`);
+  }
+
+  const data = await response.json();
+  const content = data?.output?.[0]?.content?.[0]?.text || data?.output_text;
+  if (!content) {
+    throw new Error('Missing JSON content in OpenAI response.');
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch (err) {
+    throw new Error('OpenAI returned invalid JSON.');
+  }
+}
+
+function buildMockResponse(snapshot) {
+  const inv = Array.isArray(snapshot.player_state?.inventory)
+    ? snapshot.player_state.inventory
+    : [];
+  const hasDough = inv.includes('dough');
+  const hasLoaf = inv.includes('loaf');
+  const awaitingBake = snapshot?.location?.oven_status === 'baking';
+
+  let dialogue = 'Smells like a fine morning for baking.';
+  const actions = [];
+
+  if (!inv.includes('flour')) {
+    dialogue = 'Grab some flour from the pantry and work it on the table.';
+  } else if (!hasDough) {
+    dialogue = 'Mix that flour with water on the table until you get dough.';
+  } else if (!awaitingBake) {
+    dialogue = 'Pop the dough into the oven—watch for the crust to brown!';
+  } else if (!hasLoaf) {
+    dialogue = 'The loaf should be ready soon; keep an eye on the oven window.';
+  } else {
+    dialogue = 'Lovely loaf! Someone in town will pay well for it.';
+  }
+
+  if (hasLoaf) {
+    actions.push({ type: 'start_quest', quest_id: 'morning_customers', stage: 1 });
+  }
+
+  return { dialogue, actions };
+}
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server that proxies NPC dialogue to OpenAI or a deterministic mock response
- build a browser canvas scene with Ultima-inspired movement, lighting, baking loop, and NPC interactions
- provide environment samples and package metadata for running the slice locally

## Testing
- npm install
- node server.js

------
https://chatgpt.com/codex/tasks/task_b_68cd0b172a54832792081ce901ab3ff1