### PR TITLE
Refine parallax handling in Three.js renderer

### DIFF
--- a/public/world3d.js
+++ b/public/world3d.js
@@ -665,7 +665,7 @@ function refreshPostEffectsConfig() {
   }
 }
 
-function applyParallax(cameraPos = world.cameraTarget) {
+function setParallax(cameraPos = world.cameraTarget) {
   if (!world.parallaxEnabled) {
     Object.values(world.layers).forEach((group) => {
       if (!group || !group.userData.basePosition) return;
@@ -679,8 +679,9 @@ function applyParallax(cameraPos = world.cameraTarget) {
     const group = world.layers[key];
     if (!group || !group.userData.basePosition) return;
     const base = group.userData.basePosition;
-    group.position.x = base.x - cameraPos.x * (1 - factor);
-    group.position.y = base.y - cameraPos.y * (1 - factor);
+    const parallaxFactor = 1 - factor;
+    group.position.x = base.x + cameraPos.x * parallaxFactor;
+    group.position.y = base.y + cameraPos.y * parallaxFactor;
   });
 }
 
@@ -689,7 +690,7 @@ function setCameraPosition(x = 0, y = 0) {
   world.camera.position.set(x, y, world.camera.position.z);
   world.camera.lookAt(x, y, 0);
   world.cameraTarget.set(x, y);
-  applyParallax(world.cameraTarget);
+  setParallax(world.cameraTarget);
 }
 
 export function initThreeWorld(canvas, config = {}) {
@@ -747,7 +748,7 @@ export function initThreeWorld(canvas, config = {}) {
     },
     setParallaxEnabled(enabled) {
       world.parallaxEnabled = Boolean(enabled);
-      applyParallax(world.cameraTarget);
+      setParallax(world.cameraTarget);
     }
   };
 
@@ -783,7 +784,7 @@ export function renderThreeWorld(state = {}) {
     const y = Number.isFinite(state.camera.y) ? state.camera.y : world.cameraTarget.y;
     setCameraPosition(x, y);
   } else {
-    applyParallax(world.cameraTarget);
+    setParallax(world.cameraTarget);
   }
 
   refreshPostEffectsConfig();


### PR DESCRIPTION
## Summary
- replace the internal parallax helper with `setParallax` to match the spec naming
- update the offset math so the background, mid, and near layers respect their parallax factors
- reuse the helper whenever the camera or parallax toggle changes to keep the scene aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd5a70461883278c5211cf3e5430d0