### PR TITLE
Fix composer sizing to avoid dpr squared

### DIFF
--- a/public/world3d.js
+++ b/public/world3d.js
@@ -571,9 +571,9 @@ function createPostProcessing() {
 function updateComposerSize(width, height, dpr) {
   if (!world.composer) return;
   world.composer.setPixelRatio(dpr);
-  world.composer.setSize(width * dpr, height * dpr);
-  world.outlinePass.setSize(width * dpr, height * dpr);
-  world.bloomPass.setSize(width * dpr, height * dpr);
+  world.composer.setSize(width, height);
+  world.outlinePass.setSize(width, height);
+  world.bloomPass.setSize(width, height);
 }
 
 function handleResize() {


### PR DESCRIPTION
## Summary
- update the post-processing composer and passes to size themselves using logical dimensions while still applying the device pixel ratio

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cd999917f883279bb61557f17506c4