### PR TITLE
Improve renderer grid handling for tile-based maps

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Britannia Reborn</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+    />
     <style>
       :root {
         color-scheme: dark;


### PR DESCRIPTION
## Summary
- add internal grid dimension tracking so the renderer can derive width and height from any 2D tile array before drawing
- update drawing routines to use the derived grid metadata for map rendering, screen picking, and safe-area overlays
- load the "Press Start 2P" font in the HTML shell to match the HUD's pixel-art styling

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68ce355674b48327b7e6f1e09449ad4c