### PR TITLE
Update player sprite defaults

### DIFF
--- a/public/GameMap.js
+++ b/public/GameMap.js
@@ -1,3 +1,6 @@
+export const LORD_BRITISH_SPRITE_SHEET = 'assets/sprites/Soldier-01-2-1758429653885-76805eae.png';
+export const LORD_BRITISH_SPRITE_FRAME = 'player_south_1';
+
 const TILE_DEFINITIONS = {
   grass: {
     name: 'Meadow',
@@ -338,6 +341,8 @@ export function createWorld() {
         x: 10,
         y: 10,
         sprite: 'npc',
+        spriteSheet: LORD_BRITISH_SPRITE_SHEET,
+        spriteFrame: LORD_BRITISH_SPRITE_FRAME,
         color: '#d4af37',
         dialogue: 'Welcome to my castle, brave adventurer! I am Lord British, ruler of Britannia.'
       },

--- a/public/game.js
+++ b/public/game.js
@@ -1,6 +1,6 @@
 import CharacterCreator from './CharacterCreator.js';
 import Character from './Character.js';
-import { createWorld, TileInfo } from './GameMap.js';
+import { createWorld, TileInfo, LORD_BRITISH_SPRITE_SHEET } from './GameMap.js';
 import Renderer from './render.js';
 import Player from './Player.js';
 import CombatEngine from './CombatEngine.js';
@@ -15,6 +15,7 @@ const ctx = initCanvas('game');
 const renderer = new Renderer(ctx);
 const particles = createEmitter();
 renderer.setParticles(particles);
+const DEFAULT_PLAYER_SPRITE_SHEET = 'assets/sprites/Male-17-3-1758428284774-d1ea43dc.png';
 const syncCanvasSize = () => {
   resize();
 };
@@ -754,11 +755,20 @@ async function bootstrap() {
     }
     renderer.setAtlas(atlas);
     console.log('Atlas set on renderer. Assets loaded:', renderer.assetsLoaded);
+    try {
+      await renderer.loadPlayerSprite(DEFAULT_PLAYER_SPRITE_SHEET);
+      console.log('Player sprite sheet loaded:', DEFAULT_PLAYER_SPRITE_SHEET);
+    } catch (spriteError) {
+      console.warn('Failed to load default player sprite sheet:', spriteError);
+    }
+    renderer.ensureSpriteSheet(LORD_BRITISH_SPRITE_SHEET).catch((error) => {
+      console.warn('Failed to preload Lord British sprite sheet:', error);
+    });
   } catch (error) {
     console.error('Failed to load texture atlas.', error);
     return;
   }
-  
+
   console.log('Starting renderer...');
   renderer.start();
   console.log('Renderer started. Running:', renderer.running);


### PR DESCRIPTION
## Summary
- load and cache external sprite sheets in the renderer so actors can use 3×4 PNG sheets
- set the default player model to `Male-17-3-1758428284774-d1ea43dc.png` and preload Lord British's new art
- assign Lord British to the `Soldier-01-2-1758429653885-76805eae.png` sprite sheet for in-game rendering

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cf889720cc8327810c410a35afe755