### PR TITLE
feat(world): add Village hub and connect Castle↔Village↔Forest via transitions

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -1,3 +1,4 @@
+// Feature: Village area + transitions (Castle↔Village↔Forest)
 import CharacterCreator from './CharacterCreator.js';
 import Character from './Character.js';
 import { createWorld, TileInfo, LORD_BRITISH_SPRITE_SHEET } from './GameMap.js';
@@ -531,7 +532,7 @@ async function resolveCombat(result, enemy) {
     state.character.applyDeathPenalty();
     state.character.currentHP = Math.max(state.character.currentHP, Math.floor(state.character.maxHP * 0.6));
     state.character.currentMP = Math.max(state.character.currentMP, Math.floor(state.character.maxMP * 0.4));
-    changeMap('forest', 'village');
+    changeMap('forest', 'forest_path');
   } else if (result.outcome === 'fled') {
     log('You fled from battle.');
   }
@@ -786,7 +787,7 @@ async function bootstrap() {
   state.map = state.world.startingMap;
   activeMovementDirections.clear();
   renderer.stopAllMovement();
-  changeMap(state.map.id, 'village');
+  changeMap(state.map.id, 'castle_gate');
   renderInventory();
   renderCharacterSheet();
   updateHUD();


### PR DESCRIPTION
## Summary
- create the new village layout and character map with spawn points linking to the castle gate and forest trail
- extend castle and forest maps to add transition tiles plus spawn metadata for the shared hub
- register the safe village area with friendly NPCs so world transitions route through the hub

## Testing
- `node --check public/GameMap.js` *(fails: repository uses ESM modules without `type: "module"`)*

------
https://chatgpt.com/codex/tasks/task_b_68cfdb2d43d483278feeb2113619c555