### PR TITLE
Expand tile loader search paths

### DIFF
--- a/public/renderer/tileloader.js
+++ b/public/renderer/tileloader.js
@@ -8,11 +8,23 @@ class TileLoader {
     this.cache = new Map();
     this.loading = new Map(); // Track promises to avoid duplicate loads
     this.basePaths = [
+      // existing locations
       'assets/tiles/',
       'public/assets/tiles/',
       './assets/tiles/',
-      './public/assets/tiles/'
+      './public/assets/tiles/',
+      // pixelcrawler locations (new)
+      'public/assets/pixelcrawler/',
+      'public/assets/pixelcrawler/tiles/',
+      'public/assets/pixelcrawler/props/',
+      './public/assets/pixelcrawler/',
+      './public/assets/pixelcrawler/tiles/',
+      './public/assets/pixelcrawler/props/'
     ];
+    // optional: filename aliasing (tileName -> fileName without .png)
+    this.alias = {
+      // example: 'castle_wall': 'castle/wall_stone_01'
+    };
   }
 
   async loadTile(tileName) {
@@ -45,7 +57,8 @@ class TileLoader {
   }
 
   async _loadTileFromPaths(tileName) {
-    const filename = `${tileName}.png`;
+    const stem = this.alias[tileName] || tileName;
+    const filename = `${stem}.png`;
     
     for (const basePath of this.basePaths) {
       const url = `${basePath}${filename}`;


### PR DESCRIPTION
## Summary
- add pixelcrawler asset directories to the tile loader search paths so individual PNGs are found
- introduce an optional alias map to remap tile names to different filenames when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d065b2308483278b634f2cfe8ecfd9