### PR TITLE
Preload pillar tile assets in render engine

### DIFF
--- a/public/render.js
+++ b/public/render.js
@@ -227,7 +227,7 @@ export default class RenderEngine {
       const castleTiles = [
         'castle_wall', 'castle_floor', 'red_carpet', 'throne',
         'banner', 'torch_wall', 'castle_door', 'castle_window',
-        'fountain', 'garden', 'courtyard',
+        'fountain', 'garden', 'courtyard', 'pillar',
         'bookshelf', 'barracks_bed', 'kitchen_table', 'study_desk', 'chapel_altar',
         'kitchen_hearth', 'wash_basin', 'dining_table', 'armory_rack',
         'training_dummy', 'royal_bed', 'stable_hay'


### PR DESCRIPTION
## Summary
- include the pillar tile in the castle-specific preload list so it uses the dedicated sprite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d080f2aedc8327a7069f40aa6b7981