### PR TITLE
Fix extractor asset paths

### DIFF
--- a/public/examine_sprites.html
+++ b/public/examine_sprites.html
@@ -73,7 +73,7 @@
                     }
                 }
             };
-            img.src = `/assets/pixelcrawler/tiles/${filename}`;
+            img.src = `./assets/pixelcrawler/tiles/${filename}`;
         }
         
         spriteSheets.forEach(loadSpriteSheet);

--- a/public/extract_tiles.html
+++ b/public/extract_tiles.html
@@ -78,7 +78,7 @@
                 displayTileGrid(img, select.value);
                 document.getElementById('downloadSection').style.display = 'block';
             };
-            img.src = `/assets/pixelcrawler/tiles/${select.value}`;
+            img.src = `./assets/pixelcrawler/tiles/${select.value}`;
         }
         
         function displayTileGrid(img, filename) {


### PR DESCRIPTION
## Summary
- update the extractor and sprite examiner tools to load Pixelcrawler sheets via relative paths so they work when hosted under a project subpath
- regenerate the pre-scaled 48×48 tiles from the Pixelcrawler sheets so the renderer can load individual castle assets

## Testing
- node extract_pixelcrawler_tiles.js

------
https://chatgpt.com/codex/tasks/task_b_68d12a366df483278275742001a5ef1a